### PR TITLE
Feature/worldguard support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>org.inventivetalent</groupId>
     <artifactId>bookshelves</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.bstats:bstats-bukkit**</include>
-                                    <include>org.inventivetalent:bookshelves**</include>
                                     <include>org.inventivetalent:itembuilder**</include>
                                 </includes>
                             </artifactSet>
@@ -124,6 +123,12 @@
             <artifactId>itembuilder</artifactId>
             <version>[1.0.10,)</version>
         </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -145,7 +150,7 @@
         </repository>
         <repository>
             <id>sk89q-repo</id>
-            <url>http://maven.sk89q.com/artifactory/repo/</url>
+            <url>https://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
             <id>techcable-repo</id>

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -4,4 +4,4 @@ author: inventivetalent
 version: ${project.version}
 api-version: 1.13
 
-softdepend: [GriefPrevention]
+softdepend: [GriefPrevention, WorldGuard]

--- a/src/org/inventivetalent/bookshelves/Bookshelves.java
+++ b/src/org/inventivetalent/bookshelves/Bookshelves.java
@@ -40,6 +40,7 @@ public class Bookshelves extends JavaPlugin {
 	public void onLoad() {
 		worldGuardSupport = Bukkit.getPluginManager().getPlugin("WorldGuard") != null;
 		if (worldGuardSupport) {
+			getLogger().info("Found WorldGuard plugin");
 			WorldGuardUtils.registerBookshelfAccessFlag();
 		}
 	}
@@ -92,10 +93,6 @@ public class Bookshelves extends JavaPlugin {
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
-		}
-
-		if (worldGuardSupport) {
-			getLogger().info("Found WorldGuard plugin");
 		}
 
 		Bukkit.getScheduler().runTaskLater(this, new Runnable() {

--- a/src/org/inventivetalent/bookshelves/Bookshelves.java
+++ b/src/org/inventivetalent/bookshelves/Bookshelves.java
@@ -31,9 +31,18 @@ public class Bookshelves extends JavaPlugin {
 	String      INVENTORY_TITLE = "Bookshelf";
 	Set<String> disabledWorlds  = new HashSet<>();
 	boolean     onlyBooks       = true;
+	boolean 	worldGuardSupport = false;
 
 	Set<Location> shelves   = new HashSet<>();
 	File          shelfFile = new File(getDataFolder(), "shelves.json");
+
+	@Override
+	public void onLoad() {
+		worldGuardSupport = Bukkit.getPluginManager().getPlugin("WorldGuard") != null;
+		if (worldGuardSupport) {
+			WorldGuardUtils.registerBookshelfAccessFlag();
+		}
+	}
 
 	@Override
 	public void onEnable() {
@@ -83,6 +92,10 @@ public class Bookshelves extends JavaPlugin {
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
+		}
+
+		if (worldGuardSupport) {
+			getLogger().info("Found WorldGuard plugin");
 		}
 
 		Bukkit.getScheduler().runTaskLater(this, new Runnable() {

--- a/src/org/inventivetalent/bookshelves/Bookshelves.java
+++ b/src/org/inventivetalent/bookshelves/Bookshelves.java
@@ -31,7 +31,7 @@ public class Bookshelves extends JavaPlugin {
 	String      INVENTORY_TITLE = "Bookshelf";
 	Set<String> disabledWorlds  = new HashSet<>();
 	boolean     onlyBooks       = true;
-	boolean 	worldGuardSupport = false;
+	boolean     worldGuardSupport = false;
 
 	Set<Location> shelves   = new HashSet<>();
 	File          shelfFile = new File(getDataFolder(), "shelves.json");

--- a/src/org/inventivetalent/bookshelves/ShelfListener.java
+++ b/src/org/inventivetalent/bookshelves/ShelfListener.java
@@ -37,6 +37,7 @@ public class ShelfListener implements Listener {
 
 		if (!player.hasPermission("bookshelf.open")) { return; }
 		if (player.isSneaking()) { return; }
+		if (plugin.worldGuardSupport && !WorldGuardUtils.isAllowedToAccess(player, block)) { return; }
 
 		Inventory inventory = plugin.getShelf(block);
 		if (inventory == null) { inventory = plugin.initShelf(block); }

--- a/src/org/inventivetalent/bookshelves/WorldGuardUtils.java
+++ b/src/org/inventivetalent/bookshelves/WorldGuardUtils.java
@@ -1,0 +1,49 @@
+package org.inventivetalent.bookshelves;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.inventivetalent.bookshelves.Bookshelves;
+
+import java.util.Optional;
+
+public class WorldGuardUtils {
+
+    private static final StateFlag stateFlag = new StateFlag( "bookshelf-access", false);
+
+    public static void registerBookshelfAccessFlag() {
+        try
+        {
+            WorldGuard.getInstance().getFlagRegistry().register( stateFlag );
+        }
+        catch (FlagConflictException ex)
+        {
+            Bookshelves.instance.getLogger().warning("The flag '" + stateFlag.getName() + "' is already registered by another plugin. Conflicts might occur!");
+        }
+    }
+
+    public static boolean isAllowedToAccess(Player player, Block block) {
+        if (player.hasPermission("worldguard.region.bypass." + block.getWorld().getName())) { return true; }
+
+        WorldGuard worldGuard = WorldGuard.getInstance();
+        Optional<RegionManager> regionManager = Optional.ofNullable( worldGuard.getPlatform().getRegionContainer().get(BukkitAdapter.adapt(block.getWorld())) );
+
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        BlockVector3 location = BukkitAdapter.adapt(block.getLocation()).toVector().toBlockPoint();
+
+        boolean allowChestAccess = !regionManager.isPresent() || regionManager.get().getApplicableRegions(location).testState(localPlayer, stateFlag);
+        boolean isRegionMember = !regionManager.isPresent() || regionManager.get().getApplicableRegions(location).isMemberOfAll(localPlayer);
+
+        return allowChestAccess || isRegionMember;
+    }
+
+}


### PR DESCRIPTION
Summary:

I've implemented WorldGuard-support using a custom-flag.

- If a region got the flag _bookshelf-access_ assigned and its value is allowed (deny is the default value), everybody will be able to access bookshelves within that region. 
- If the flag wasn't assigned manually only members and owners of the region will be allowed to access the bookshelves within that region. 
- It's also possible to access bookshelves if the player has the region-bypass permission.

Testing:
- [x] I've tested the plugin on 1.14.3-R0.1-SNAPSHOT without any problems.